### PR TITLE
TE-5514 Use new Column for column definition in unique to fix diff is…

### DIFF
--- a/src/Spryker/Zed/UuidBehavior/Persistence/Propel/Behavior/UuidBehavior.php
+++ b/src/Spryker/Zed/UuidBehavior/Persistence/Propel/Behavior/UuidBehavior.php
@@ -8,6 +8,7 @@
 namespace Spryker\Zed\UuidBehavior\Persistence\Propel\Behavior;
 
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Unique;
 use Spryker\Zed\UuidBehavior\Persistence\Propel\Behavior\Exception\ColumnNotFoundException;
@@ -87,7 +88,7 @@ class UuidBehavior extends Behavior
 
             $uniqueIndex = new Unique();
             $uniqueIndex->setName($table->getName() . static::KEY_COLUMN_UNIQUE_INDEX_POSTFIX);
-            $uniqueIndex->addColumn($column);
+            $uniqueIndex->addColumn(new Column(static::KEY_COLUMN_NAME));
             $table->addUnique($uniqueIndex);
         }
     }


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-5514

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/2581

- Release Overview: https://release.spryker.com/release/pull-request-core/SynchronizationBehavior/19

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   UuidBehavior                | patch                 |                       |

-----------------------------------------

#### Module UuidBehavior

##### Change log

Fixes

- Fixed issue with always created migration file on MySQL database by adding a new Column instead of using the reference to the created column.

